### PR TITLE
New assembly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ACEfit"
 uuid = "ad31a8ef-59f5-4a01-b543-a85c2f73e95c"
 authors = ["William C Witt <witt.chuck@gmail.com>, Christoph Ortner <christophortner0@gmail.com> and contributors"]
-version = "0.1.4"
+version = "0.1.5-DEV"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -9,9 +9,7 @@ IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LowRankApprox = "898213cb-b102-5a47-900c-97e73b919f73"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
-ParallelDataTransfer = "2dcacdae-9679-587a-88bb-8b444fb7085b"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
-SharedArrays = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
@@ -33,7 +31,6 @@ MLJLinearModels = "0.9"
 MLJScikitLearnInterface = "0.5"
 LowRankApprox = "0.5.3"
 Optim = "1.7"
-ParallelDataTransfer = "0.5.0"
 ProgressMeter = "1.7"
 PythonCall = "0.9"
 StaticArrays = "1.5"


### PR DESCRIPTION
This will add the new assemble function.

On my tests, the current fitting methods in ACEpotentials will get most of speed increases the new assemble brings in. But the AtomsBase framework should be a little bit faster due to extra threading and the evaluate_d improvement. 

I removed the dependencies from the old assemble (ParallelDataTransfer and SharedArrays).

I left progress meter in place, even though it might not have use in most cases now.

I added kwargs option to assemble to transmit extra options to calculators. If you don't give any kwargs, the old use cases should work. But ideally in the future, when you implement `feature_matrix`, `target_vector` or `weight_vector` you should add `kwargs...` to the function call. There is no need to use kwargs to anywhere, only catch them.