### PR TITLE
warm-start selection using `Select`

### DIFF
--- a/src/asp.jl
+++ b/src/asp.jl
@@ -140,3 +140,10 @@ function post_asp_tsvd(path, At, yt, Av, yv)
 
    return _post.(path)
 end
+
+function select(tracer, solver, A, y) #can be called by the user to warm-start the selection
+    xs, in = select_solution(tracer, solver, A, y)
+    return Dict("C" => xs, 
+                "path" => tracer, 
+                "nnzs" => length( (tracer[in][:solution]).nzind) )  
+end

--- a/test/test_asp.jl
+++ b/test/test_asp.jl
@@ -117,3 +117,41 @@ for (select, tolr, tolc) in [ (:final, 20*epsn, 1.5),
    end
 end
 
+
+# Testing the "select" function 
+solver_final = ACEfit.ASP(
+    P = I, 
+    select = :final, 
+    tsvd = false, 
+    nstore = 100, 
+    loglevel = 0
+)
+
+results_final = ACEfit.solve(solver_final, At, yt, Av, yv)
+tracer_final = results_final["path"]
+
+# Warm-start the solver using the tracer from the final iteration
+solver_warmstart = ACEfit.ASP(
+    P = I, 
+    select = (:bysize, 73), 
+    tsvd = false, 
+    nstore = 100, 
+    loglevel = 0
+)
+
+results_warmstart = ACEfit.select(tracer_final, solver_warmstart, Av, yv)
+C_warmstart = results_warmstart["C"]
+
+# Check if starting the solver initially with (:bysize, 73) gives the same result
+solver_bysize = ACEfit.ASP(
+    P = I, 
+    select = (:bysize, 73), 
+    tsvd = false, 
+    nstore = 100, 
+    loglevel = 0
+)
+
+results_bysize = ACEfit.solve(solver_bysize, At, yt, Av, yv)
+@test results_bysize["C"] == C_warmstart  # works
+
+


### PR DESCRIPTION
This PR adds a function called `select` to the asp framework. The user can call `select(tracer, solver, A, y)` to warm-start a new selection using a previously computed tracer.